### PR TITLE
Add nerdtree to init.lua

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -263,6 +263,15 @@ require('lazy').setup({
       vim.cmd.colorscheme 'gruvbox'
     end,
   },
+  {
+    'preservim/nerdtree',
+    config = function()
+      -- NERDTree Settings
+      vim.g.NERDTreeShowHidden = 1 -- Show hidden files in NERDTree
+      -- Key mappings to toggle NERDTree
+      vim.api.nvim_set_keymap('n', '<F12>', ':NERDTreeToggle<CR>', { noremap = true, silent = true })
+    end,
+  },
 
   -- NOTE: Plugins can also be configured to run Lua code when they are loaded.
   --

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -14,6 +14,7 @@
   "mason-tool-installer.nvim": { "branch": "main", "commit": "c5e07b8ff54187716334d585db34282e46fa2932" },
   "mason.nvim": { "branch": "main", "commit": "e2f7f9044ec30067bc11800a9e266664b88cda22" },
   "mini.nvim": { "branch": "main", "commit": "b07157c51e52a1b004ec7959f9618e9bc24686d3" },
+  "nerdtree": { "branch": "master", "commit": "9b465acb2745beb988eff3c1e4aa75f349738230" },
   "nvim-cmp": { "branch": "main", "commit": "f17d9b4394027ff4442b298398dfcaab97e40c4f" },
   "nvim-lspconfig": { "branch": "master", "commit": "f012c1b176f0e3c71f40eb309bdec0316689462e" },
   "nvim-treesitter": { "branch": "master", "commit": "1c0cbdef44a2cc35c6436e0866a2a5282b339ffd" },


### PR DESCRIPTION
This PR:

- Adds NERDTree to my neovim config in the .config/nvim/init.lua file
- Adds a keybinding for F12 to toggle NERDTree on and off

